### PR TITLE
Use itunes elements if there is no rss element 

### DIFF
--- a/meego/podcastrssparser.cpp
+++ b/meego/podcastrssparser.cpp
@@ -61,9 +61,7 @@ bool PodcastRSSParser::populateChannelFromChannelXML(PodcastChannel *channel, QB
         QString url = imageNode.firstChildElement("url").text(); // And the url to it.
 
         if (url.isEmpty()){
-            qWarning() << "No RSS image url found";
             nodeList = channelNode.toElement().elementsByTagName("itunes:image");
-            qDebug() << nodeList.length();
             imageNode = nodeList.at(0);
             url = imageNode.toElement().attribute("href");
         }

--- a/meego/podcastrssparser.cpp
+++ b/meego/podcastrssparser.cpp
@@ -56,8 +56,21 @@ bool PodcastRSSParser::populateChannelFromChannelXML(PodcastChannel *channel, QB
     channel->setDescription(channelNode.firstChildElement("description").text());
 
     if (channel->logoUrl().isEmpty()) {
-        QDomNode imageNode = channelNode.toElement().elementsByTagName("image").at(0); // Find the logo.
-        channel->setLogoUrl(imageNode.firstChildElement("url").text());                // And the url to it.
+        QDomNodeList nodeList = channelNode.toElement().elementsByTagName("image");
+        QDomNode imageNode = nodeList.at(0); // Find the logo.
+        QString url = imageNode.firstChildElement("url").text(); // And the url to it.
+
+        if (url.isEmpty()){
+            qWarning() << "No RSS image url found";
+            nodeList = channelNode.toElement().elementsByTagName("itunes:image");
+            qDebug() << nodeList.length();
+            imageNode = nodeList.at(0);
+            url = imageNode.toElement().attribute("href");
+        }
+
+        if (!url.isEmpty())
+            channel->setLogoUrl(url);
+
     }
 
     channel->dumpInfo();
@@ -104,6 +117,10 @@ bool PodcastRSSParser::populateEpisodesFromChannelXML(QList<PodcastEpisode *> *e
 
         episode->setTitle(node.firstChildElement("title").text());
         episode->setDescription(node.firstChildElement("description").text());
+
+        if (episode->description().isEmpty())
+            episode->setDescription(node.firstChildElement("itunes:summary").text());
+
         episode->setDuration(node.firstChildElement("itunes:duration").text());
 
         QDomNamedNodeMap attrMap = node.firstChildElement("enclosure").attributes();


### PR DESCRIPTION
Many feeds use itunes:image instead of <image> for the channel image, so this should also get checked when parsing the feed.
Some feeds use itunes:summary and have no <description>, so this info should be used.
